### PR TITLE
Accept .save() options such as DB transaction.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
 
 module.exports = bookshelf => {
   bookshelf.Model = bookshelf.Model.extend({
-    upsert (attributes) {
-      return this.save(attributes, { method: 'update' })
+    upsert (attributes, options = {}) {
+      return this.save(attributes, Object.assign({ method: 'update' }, options))
       .catch(err => {
         if (err instanceof bookshelf.Model.NoRowsUpdatedError) {
-          return this.save(attributes, { method: 'insert' })
+          return this.save(attributes, Object.assign({ method: 'insert' }, options))
         }
         throw err
       })


### PR DESCRIPTION
Hello, thanks for your plugin. 

I was not able to preform upserts in a DB transaction, so I've modified the method to accept `options` object to fix it. Here is a description of the [Bookshelf `.save()` options](http://bookshelfjs.org/#Model-instance-save).

Cheers!